### PR TITLE
feat: add posterize filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
           <button class="btn category-btn" id="cat-draw" disabled>Draw <kbd>D</kbd></button>
           <button class="btn category-btn" id="cat-merge" disabled>Merge <kbd>M</kbd></button>
           <button class="btn category-btn" id="cat-adjust" disabled>Adjust <kbd>A</kbd></button>
+          <button class="btn category-btn" id="cat-filters" disabled>Filters <kbd>L</kbd></button>
         </div>
 
         <div id="panel-transform" class="tool-panel hidden">
@@ -131,6 +132,14 @@
             <span id="saturation-value">100%</span>
           </div>
           <button id="reset-adjustments-btn" class="btn btn-sm btn-ghost" disabled>Reset adjustments <kbd>0</kbd></button>
+        </div>
+
+        <div id="panel-filters" class="tool-panel hidden">
+          <div class="slider-group">
+            <label>Posterize <kbd>P</kbd></label>
+            <input type="range" id="posterize-slider" min="0" max="6" value="0" disabled />
+            <span id="posterize-value">Off</span>
+          </div>
         </div>
       </footer>
 

--- a/src/editor/ImageEditor.ts
+++ b/src/editor/ImageEditor.ts
@@ -10,6 +10,7 @@ import { ShapeOperation } from '../operations/ShapeOperation';
 import { UpscaleOperation } from '../operations/UpscaleOperation';
 import { RemoveBgOperation, MaskCache } from '../operations/RemoveBgOperation';
 import { RefineMaskOperation, MaskStroke } from '../operations/RefineMaskOperation';
+import { PosterizeOperation } from '../operations/PosterizeOperation';
 
 const DEFAULT_ADJUSTMENTS: AdjustmentValues = { brightness: 100, contrast: 100, saturation: 100 };
 
@@ -151,6 +152,22 @@ export class ImageEditor {
 
   async upscale(scale: number): Promise<void> {
     await this.applyOperation(new UpscaleOperation(scale));
+  }
+
+  async posterize(levels: number): Promise<void> {
+    await this.applyOperation(new PosterizeOperation(levels));
+  }
+
+  previewPosterize(levels: number): void {
+    const filter = this.pendingAdjustments
+      ? AdjustOperation.buildFilter(this.pendingAdjustments)
+      : undefined;
+    this.canvas.updatePreview(filter);
+    const ctx = this.canvas.getPreviewContext();
+    const previewCanvas = this.canvas.getPreviewCanvas();
+    const imageData = ctx.getImageData(0, 0, previewCanvas.width, previewCanvas.height);
+    PosterizeOperation.applyToPixels(imageData.data, levels);
+    ctx.putImageData(imageData, 0, 0);
   }
 
   async applyRefineMask(strokes: MaskStroke[]): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { MergeDialog } from './ui/MergeDialog';
 import { ShapeDrawer } from './ui/ShapeDrawer';
 import { CategoryTabs } from './ui/CategoryTabs';
 import { MaskBrush } from './ui/MaskBrush';
+import { Filters } from './ui/Filters';
 import { setupKeyboardShortcuts } from './ui/KeyboardShortcuts';
 
 function init(): void {
@@ -13,16 +14,19 @@ function init(): void {
 
   let toolbar!: Toolbar;
   let sliders!: Sliders;
+  let filters!: Filters;
   let categoryTabs!: CategoryTabs;
 
   const editor = new ImageEditor(canvas, () => {
     toolbar.updateState();
     sliders.updateState();
+    filters.updateState();
     categoryTabs.updateState(editor.hasImage());
   });
 
   toolbar = new Toolbar(editor);
   sliders = new Sliders(editor);
+  filters = new Filters(editor);
 
   // Declared with let! so the cross-deactivation callbacks can reference each
   // other without initialisation order issues (callbacks are invoked later).

--- a/src/operations/PosterizeOperation.ts
+++ b/src/operations/PosterizeOperation.ts
@@ -1,0 +1,33 @@
+import { BaseOperation } from './Operation';
+
+export class PosterizeOperation extends BaseOperation {
+  constructor(private levels: number) {
+    super();
+  }
+
+  static applyToPixels(data: Uint8ClampedArray, levels: number): void {
+    const step = 255 / (levels - 1);
+    for (let i = 0; i < data.length; i += 4) {
+      data[i]     = Math.round(Math.floor(data[i]     * levels / 256) * step);
+      data[i + 1] = Math.round(Math.floor(data[i + 1] * levels / 256) * step);
+      data[i + 2] = Math.round(Math.floor(data[i + 2] * levels / 256) * step);
+      // alpha (i + 3) unchanged
+    }
+  }
+
+  async apply(_ctx: OffscreenCanvasRenderingContext2D, image: ImageBitmap): Promise<ImageBitmap> {
+    const canvas = new OffscreenCanvas(image.width, image.height);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Could not get context');
+
+    ctx.drawImage(image, 0, 0);
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    PosterizeOperation.applyToPixels(imageData.data, this.levels);
+    ctx.putImageData(imageData, 0, 0);
+    return this.createImageBitmap(canvas);
+  }
+
+  getDescription(): string {
+    return `Posterize (${this.levels} levels)`;
+  }
+}

--- a/src/ui/CategoryTabs.ts
+++ b/src/ui/CategoryTabs.ts
@@ -1,8 +1,8 @@
-type Category = 'transform' | 'crop' | 'draw' | 'merge' | 'adjust';
+type Category = 'transform' | 'crop' | 'draw' | 'merge' | 'adjust' | 'filters';
 
 export class CategoryTabs {
   private activeCategory: Category | null = null;
-  private readonly categories: Category[] = ['transform', 'crop', 'draw', 'merge', 'adjust'];
+  private readonly categories: Category[] = ['transform', 'crop', 'draw', 'merge', 'adjust', 'filters'];
   private onDeactivate: Partial<Record<Category, () => void>>;
 
   constructor(onDeactivate: Partial<Record<Category, () => void>> = {}) {

--- a/src/ui/Filters.ts
+++ b/src/ui/Filters.ts
@@ -1,0 +1,39 @@
+import { ImageEditor } from '../editor/ImageEditor';
+
+export class Filters {
+  private editor: ImageEditor;
+  private posterizeSlider: HTMLInputElement;
+  private posterizeValue: HTMLSpanElement;
+
+  constructor(editor: ImageEditor) {
+    this.editor = editor;
+    this.posterizeSlider = document.getElementById('posterize-slider') as HTMLInputElement;
+    this.posterizeValue = document.getElementById('posterize-value') as HTMLSpanElement;
+    this.setupEventListeners();
+  }
+
+  private setupEventListeners(): void {
+    this.posterizeSlider.addEventListener('input', () => {
+      const sliderValue = parseInt(this.posterizeSlider.value);
+      if (sliderValue === 0) {
+        this.posterizeValue.textContent = 'Off';
+        this.editor.refreshPreview();
+      } else {
+        const levels = 8 - sliderValue;
+        this.posterizeValue.textContent = `${levels} levels`;
+        this.editor.previewPosterize(levels);
+      }
+    });
+
+    this.posterizeSlider.addEventListener('change', async () => {
+      const sliderValue = parseInt(this.posterizeSlider.value);
+      if (sliderValue === 0) return;
+      const levels = 8 - sliderValue;
+      await this.editor.posterize(levels);
+    });
+  }
+
+  updateState(): void {
+    this.posterizeSlider.disabled = !this.editor.hasImage();
+  }
+}

--- a/src/ui/KeyboardShortcuts.ts
+++ b/src/ui/KeyboardShortcuts.ts
@@ -32,6 +32,7 @@ export function setupKeyboardShortcuts(): void {
       case 'd': click('cat-draw'); break;
       case 'm': click('cat-merge'); break;
       case 'a': click('cat-adjust'); break;
+      case 'l': click('cat-filters'); break;
 
       case 'h': click('flip-h-btn'); break;
       case 'v': click('flip-v-btn'); break;
@@ -47,6 +48,7 @@ export function setupKeyboardShortcuts(): void {
       case 'b': focus('brightness-slider'); break;
       case 'k': focus('contrast-slider'); break;
       case 's': focus('saturation-slider'); break;
+      case 'p': focus('posterize-slider'); break;
       case '0': click('reset-adjustments-btn'); break;
     }
   });

--- a/src/ui/Sliders.ts
+++ b/src/ui/Sliders.ts
@@ -10,7 +10,6 @@ export class Sliders {
   private contrastValue: HTMLSpanElement;
   private saturationValue: HTMLSpanElement;
   private resetBtn: HTMLButtonElement;
-
   constructor(editor: ImageEditor) {
     this.editor = editor;
 
@@ -40,6 +39,7 @@ export class Sliders {
       this.resetSliderValues();
       this.editor.resetPreview();
     });
+
   }
 
   private getValues(): AdjustmentValues {


### PR DESCRIPTION
Closes #2

## Summary
- Adds `PosterizeOperation` that reduces each RGB channel to N discrete tonal levels via pixel manipulation
- Live preview on slider drag (preview resolution, no history entry); commits full-res to history on mouse release
- Slider range 0–6: `0` = Off (no effect), `6` = maximum posterize (2 levels — near black & white)
- New **Filters** tab (`L`) to house filter-type operations, keeping them separate from color adjustments
- New `Filters` UI component owns the filter panel, following the same pattern as `Sliders`
- Keyboard shortcut `P` focuses the posterize slider when the Filters panel is open

## Test plan
- [x] Upload an image and open the Filters tab (`L`)
- [x] Drag the Posterize slider — preview should update live as you drag
- [x] Release the slider — effect is committed to history, undo/redo works
- [x] Slider at `0` shows the original image (no effect)
- [x] Export PNG/JPEG and verify the posterized output matches the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)