### PR TITLE
feat: allow uploading image via Ctrl+V paste

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         <div class="toolbar-left">
           <label class="btn">
             <input type="file" id="upload-input" accept="image/*" hidden />
-            Upload <kbd>Ctrl+O</kbd>
+            Upload <kbd>Ctrl+O</kbd> <kbd>Ctrl+V</kbd>
           </label>
           <div class="separator"></div>
           <button id="undo-btn" class="btn btn-ghost" disabled>Undo <kbd>Ctrl+Z</kbd></button>

--- a/src/ui/Toolbar.ts
+++ b/src/ui/Toolbar.ts
@@ -68,6 +68,18 @@ export class Toolbar {
     document.getElementById('flip-v-btn')?.addEventListener('click', () => this.editor.flipVertical());
     document.getElementById('rotate-cw-btn')?.addEventListener('click', () => this.editor.rotate(90));
     document.getElementById('rotate-ccw-btn')?.addEventListener('click', () => this.editor.rotate(-90));
+
+    document.addEventListener('paste', async (e) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) await this.editor.loadImage(file);
+          break;
+        }
+      }
+    });
   }
 
   updateState(): void {


### PR DESCRIPTION
Closes #1

## Summary
- Adds a `paste` event listener on the document in `Toolbar.ts`
- Iterates clipboard items and loads the first image found via `editor.loadImage()`
- Works with screenshots, images copied from the browser, or any other image in the clipboard
- Updated the Upload button to show the `Ctrl+V` hint alongside `Ctrl+O`

## Test plan
- [x] Copy an image from anywhere (browser, screenshot tool, file manager)
- [x] Press `Ctrl+V` — image should load into the editor
- [x] Pasting text while a text input is focused should be unaffected (no image type in clipboard items)
- [x] `Ctrl+O` file picker still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)